### PR TITLE
perf(lifecycle): Prevent rerender of child components that use $liste…

### DIFF
--- a/src/core/instance/lifecycle.js
+++ b/src/core/instance/lifecycle.js
@@ -6,7 +6,7 @@ import { mark, measure } from '../util/perf'
 import { createEmptyVNode } from '../vdom/vnode'
 import { updateComponentListeners } from './events'
 import { resolveSlots } from './render-helpers/resolve-slots'
-import { toggleObserving } from '../observer/index'
+import { toggleObserving, toggleNotifyingSubscribers } from '../observer/index'
 import { pushTarget, popTarget } from '../observer/dep'
 
 import {
@@ -257,8 +257,13 @@ export function updateChildComponent (
   // update $attrs and $listeners hash
   // these are also reactive so they may trigger child update if the child
   // used them during render
-  vm.$attrs = parentVnode.data.attrs || emptyObject
+
+  // Disable subscribers notification in setter to avoid rerendering a child that uses $listeners
+  toggleNotifyingSubscribers(false)
   vm.$listeners = listeners || emptyObject
+  toggleNotifyingSubscribers(true)
+
+  vm.$attrs = parentVnode.data.attrs || emptyObject
 
   // update props
   if (propsData && vm.$options.props) {

--- a/src/core/observer/index.js
+++ b/src/core/observer/index.js
@@ -29,6 +29,17 @@ export function toggleObserving (value: boolean) {
 }
 
 /**
+ * In some cases we may want to disable the run of all subscribers
+ * inside a component's update computation.
+ */
+export let shouldNotifySubscribers: boolean = true
+
+
+export function toggleNotifyingSubscribers (value: boolean) {
+  shouldNotifySubscribers = value
+}
+
+/**
  * Observer class that is attached to each observed
  * object. Once attached, the observer converts the target
  * object's property keys into getter/setters that
@@ -188,7 +199,7 @@ export function defineReactive (
         val = newVal
       }
       childOb = !shallow && observe(newVal)
-      dep.notify()
+      shouldNotifySubscribers && dep.notify()
     }
   })
 }


### PR DESCRIPTION
Child components that use the $listeners attribute are rerendered each time the parent component is
updated. This is due to the updateChildComponent function that sets the reactive property
vm.$listeners thus triggering a rerender of the child component. The problem is that we cannot check
if the listeners were updated as we cannot compare functions. This change therefore provides a new
toggleNotifyingSubscribers method that disables a reactive property's ability to notify its
subscribers. We use this method to prevent the vm.$listeners property from rerendering the child
component.

fix #7257